### PR TITLE
Fix bug with single-number scenarios

### DIFF
--- a/app/src/main/java/com/google/samples/apps/gameloopmanager/TestLoopsActivity.java
+++ b/app/src/main/java/com/google/samples/apps/gameloopmanager/TestLoopsActivity.java
@@ -308,7 +308,7 @@ public class TestLoopsActivity extends AppCompatActivity {
         for (String key : metaData.keySet()) {
           if (key.startsWith("com.google.test.loops.")) {
             List<Integer> loops = new ArrayList<>();
-            String loopsList = metaData.getString(key);
+            String loopsList = String.valueOf(metaData.get(key));
             String[] loopsArray = loopsList.split(",");
             for (String s : loopsArray) {
               if (s.contains("-")) {


### PR DESCRIPTION
Single-number scenarios caused the Test Loop Manager to fail to parse
the value in the Bundle and therefore they would fail to show up
altogether. This fix simply allows them to be either a number or a
string.