### PR TITLE
Fix bug with single-number scenarios

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,10 +36,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/java/com/google/samples/apps/gameloopmanager/TestLoopsActivity.java
+++ b/app/src/main/java/com/google/samples/apps/gameloopmanager/TestLoopsActivity.java
@@ -308,7 +308,7 @@ public class TestLoopsActivity extends AppCompatActivity {
         for (String key : metaData.keySet()) {
           if (key.startsWith("com.google.test.loops.")) {
             List<Integer> loops = new ArrayList<>();
-            String loopsList = metaData.getString(key);
+            String loopsList = String.valueOf(metaData.get(key));
             String[] loopsArray = loopsList.split(",");
             for (String s : loopsArray) {
               if (s.contains("-")) {

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,14 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -31,6 +36,10 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 13 11:25:39 GMT 2017
+#Wed Oct 02 05:30:36 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Single-number scenarios caused the Test Loop Manager to fail to parse
the value in the Bundle and therefore they would fail to show up
altogether. This fix simply allows them to be either a number or a
string.

Also update to latest version of Gradle.